### PR TITLE
ASA-194: Add templates for bugs, feature requests and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -40,6 +40,7 @@ body:
         - R 3.6.x
         - R 4.0.x
         - R 4.1.x
+        - Other
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,61 @@
+name: 🐛 Bug Report
+description: File a bug report
+title: "[Bug]: <title>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: What version of itscalledsoccer are you using?
+      options:
+        - 0.1.0
+        - 0.1.1
+    validations:
+      required: true
+  - type: dropdown
+    id: python-or-r-versions
+    attributes:
+      label: What version of Python or R are you using?
+      multiple: false
+      options:
+        - Python 3.7.x
+        - Python 3.8.x
+        - Python 3.9.x
+        - Python 3.10.x
+        - R 3.5.x
+        - R 3.6.x
+        - R 4.0.x
+        - R 4.1.x
+    validations:
+      required: true
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: What operating system are you using?
+      multiple: false
+      options:
+        - MacOS
+        - Windows
+        - Linux
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,12 @@
+name: ✨ Feature Request
+description: Submit a feature request
+title: "[Feature Request]: <title>"
+labels: ["feature-request"]
+body:
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What feature would you like to see?
+      placeholder: Tell us what you want.
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+### Description
+
+Please explain the changes you made here.
+
+### Checklist
+
+- [ ] Code compiles correctly
+- [ ] Created tests which fail without the change (if applicable)
+- [ ] All lint and unit tests passing
+- [ ] Extended the README / documentation, if necessary
+
+### Additional Comments
+
+Anything else you'd like to add.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@ Please explain the changes you made here.
 - [ ] Created tests which fail without the change (if applicable)
 - [ ] All lint and unit tests passing
 - [ ] Extended the README / documentation, if necessary
+  - [ ] Updated NEWS.md if modifying the R package
 
 ### Additional Comments
 


### PR DESCRIPTION
Here's some info on the syntax and structure for these templates:

- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms
- https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema