### PR TITLE
ASA-201: Fix bug when grabbing entities > 1000

### DIFF
--- a/python-package/itscalledsoccer/client.py
+++ b/python-package/itscalledsoccer/client.py
@@ -242,7 +242,7 @@ class AmericanSoccerAnalysis:
         if isinstance(response, pd.DataFrame):
             offset = self.MAX_API_LIMIT
 
-            while len(temp_response) == self.MAX_API_LIMIT:
+            while len(temp_response.index) == self.MAX_API_LIMIT:
                 params["offset"] = str(offset)
                 temp_response = self._single_request(url, params)
                 response = response.append(temp_response)

--- a/python-package/itscalledsoccer/client.py
+++ b/python-package/itscalledsoccer/client.py
@@ -63,9 +63,7 @@ class AmericanSoccerAnalysis:
         df = pd.DataFrame([])
         for league in self.LEAGUES:
             url = f"{self.BASE_URL}{league}/{plural_type}"
-            response = self.session.get(url).json()
-            # Convert list of objects to JSON
-            resp_df = pd.read_json(json.dumps(response, default=lambda x: x.__dict__))
+            resp_df = self._execute_query(url, {})
             resp_df = resp_df.assign(competition=league)
             df = df.append(resp_df)
         return df
@@ -246,7 +244,7 @@ class AmericanSoccerAnalysis:
 
             while len(temp_response) == self.MAX_API_LIMIT:
                 params["offset"] = str(offset)
-                temp_response = self._execute_query(url, params)
+                temp_response = self._single_request(url, params)
                 response = response.append(temp_response)
                 offset = offset + self.MAX_API_LIMIT
 

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as f:
 setup(
     name="itscalledsoccer",
     packages=find_packages(exclude=["tests", "tests.*"]),
-    version="0.1.3",
+    version="0.1.4",
     description="Programmatically interact with the American Soccer Analysis API",
     long_description=long_description,
     long_description_content_type = "text/markdown",


### PR DESCRIPTION
### Description

Fixing a bug where when initializing the client, it only grabs the first 1000 "entities" (e.g players, managers, etc.) if there are more than 1000.  #23 

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if applicable)
- [x] All lint and unit tests passing
- [x] Extended the README / documentation, if necessary
  - [x] Updated NEWS.md if modifying the R package

### Additional Comments

Anything else you'd like to add.
