### PR TITLE
Lazy load entities on client initialization

### DIFF
--- a/itscalledsoccer/client.py
+++ b/itscalledsoccer/client.py
@@ -56,15 +56,15 @@ class AmericanSoccerAnalysis:
         self.referees: DataFrame = None
 
         if self.lazy_load:
-            print("Lazy loading enabled. Initializing client without entity data.")
+            self.LOGGER.info("Lazy loading enabled. Initializing client without entity data.")
         else:
-            print("Lazy loading disabled. Initializing client with entity data.")
+            self.LOGGER.info("Lazy loading disabled. Initializing client with entity data.")
             self.players = self._get_entity("player")
             self.teams = self._get_entity("team")
             self.stadia = self._get_entity("stadia")
             self.managers = self._get_entity("manager")
             self.referees = self._get_entity("referee")
-        print("Finished initializing client")
+        self.LOGGER.info("Finished initializing client")
 
     def _get_entity(self, type: str) -> DataFrame:
         """Gets all the data for a specific type and

--- a/itscalledsoccer/client.py
+++ b/itscalledsoccer/client.py
@@ -19,13 +19,14 @@ class AmericanSoccerAnalysis:
     LOGGER = getLogger(__name__)
 
     def __init__(
-        self, proxies: Optional[dict] = None, logging_level: Optional[str] = "WARNING"
+        self, proxies: Optional[dict] = None, logging_level: Optional[str] = "WARNING", lazy_load: Optional[bool] = True
     ) -> None:
         """Class constructor
 
         Args:
             proxies (Optional[dict], optional): A dictionary containing proxy mappings, see https://docs.python-requests.org/en/latest/user/advanced/#proxies. Defaults to None.
             logging_level (Optional[str], optional): A string representing the logging level of the logger. Defaults to "WARNING".
+            lazy_load (Optional[bool], optional): A boolean indicating whether to lazy load all entity data on initialization. Defaults to True.
         """
         SESSION = requests.session()
         if proxies:
@@ -46,11 +47,22 @@ class AmericanSoccerAnalysis:
 
         self.session = CACHE_SESSION
         self.base_url = self.BASE_URL
-        self.players = self._get_entity("player")
-        self.teams = self._get_entity("team")
-        self.stadia = self._get_entity("stadia")
-        self.managers = self._get_entity("manager")
-        self.referees = self._get_entity("referee")
+        self.lazy_load = lazy_load
+
+        if self.lazy_load:
+            print("Lazy loading enabled. Initializing client without entity data.")
+            self.players = None
+            self.teams = None
+            self.stadia = None
+            self.managers = None
+            self.referees = None
+        else:
+            print("Lazy loading disabled. Initializing client with entity data.")
+            self.players = self._get_entity("player")
+            self.teams = self._get_entity("team")
+            self.stadia = self._get_entity("stadia")
+            self.managers = self._get_entity("manager")
+            self.referees = self._get_entity("referee")
         print("Finished initializing client")
 
     def _get_entity(self, type: str) -> DataFrame:
@@ -392,6 +404,8 @@ class AmericanSoccerAnalysis:
         Returns:
             DataFrame
         """
+        if self.stadia is None:
+            self.stadia = self._get_entity("stadium")
         stadia = self._filter_entity(self.stadia, "stadium", leagues, ids, names)
         return stadia
 
@@ -411,6 +425,8 @@ class AmericanSoccerAnalysis:
         Returns:
             DataFrame
         """
+        if self.referees is None:
+            self.referees = self._get_entity("referee")
         referees = self._filter_entity(self.referees, "referee", leagues, ids, names)
         return referees
 
@@ -430,6 +446,8 @@ class AmericanSoccerAnalysis:
         Returns:
             DataFrame_
         """
+        if self.managers is None:
+            self.managers = self._get_entity("manager")
         managers = self._filter_entity(self.managers, "manager", leagues, ids, names)
         return managers
 
@@ -449,6 +467,8 @@ class AmericanSoccerAnalysis:
         Returns:
             DataFrame_
         """
+        if self.teams is None:
+            self.teams = self._get_entity("team")
         teams = self._filter_entity(self.teams, "team", leagues, ids, names)
         return teams
 
@@ -468,6 +488,8 @@ class AmericanSoccerAnalysis:
         Returns:
             DataFrame_
         """
+        if self.players is None:
+            self.players = self._get_entity("player") 
         players = self._filter_entity(self.players, "player", leagues, ids, names)
         return players
 

--- a/itscalledsoccer/client.py
+++ b/itscalledsoccer/client.py
@@ -49,13 +49,14 @@ class AmericanSoccerAnalysis:
         self.base_url = self.BASE_URL
         self.lazy_load = lazy_load
 
+        self.players: DataFrame = None
+        self.teams: DataFrame = None
+        self.stadia: DataFrame = None
+        self.managers: DataFrame = None
+        self.referees: DataFrame = None
+
         if self.lazy_load:
             print("Lazy loading enabled. Initializing client without entity data.")
-            self.players = None
-            self.teams = None
-            self.stadia = None
-            self.managers = None
-            self.referees = None
         else:
             print("Lazy loading disabled. Initializing client with entity data.")
             self.players = self._get_entity("player")

--- a/tests/features/steps/common_steps.py
+++ b/tests/features/steps/common_steps.py
@@ -81,4 +81,4 @@ def step_impl(context, function, args):
     else:
         print("Function not recognized")
         raise NameError
-    context.response = read_json(f.open())
+    context.response = read_json(f.open(encoding='utf-8'))


### PR DESCRIPTION
Lazy load entities on client initialization

### Description

Lazy load entities (players, teams, stadia, managers, referees) on client initialization. This is related to https://github.com/American-Soccer-Analysis/itscalledsoccer/issues/169

- Add `lazy_load` parameter to the `AmericanSoccerAnalysis` constructor. If it is set to true, then all entities (players, teams, stadia, managers, referees) will be initialized to None, else they will be initialized.
- All of the entity getter functions (`get_stadia`, `get_teams`, etc) load the entity data if `self.<entity>` is None. 

### Checklist

- [X] Code compiles correctly
- [X] Created tests which fail without the change (if applicable)
- [X] All lint and unit tests passing
- [X] Extended the README / documentation, if necessary

### Additional Comments

I also updated `tests\features\steps\common_steps.py` to read the mock payloads with `encoding='utf-8'`. The behave tests were failing for me without explicit utf-8 encoding.