### PR TITLE
fix: add write permission for trusted publishing

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    name: Upload release to PyPI
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
### Description

This should fix the deploy error to PyPI

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if applicable)
- [x] All lint and unit tests passing
- [x] Extended the README / documentation, if necessary
