### PR TITLE
remove file.open() to prevent encoding issues while testing on windows

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -35,7 +35,7 @@ class TestClient:
     def load_mock_data(self, func_name: str):
         path = Path(__file__).parent
         file = Path(path, f"./mocks/{func_name}_payload.json")
-        return read_json(file.open())
+        return read_json(file)
 
     def test_get_player_xgoals(self, init_client):
         self.client = init_client


### PR DESCRIPTION
### Description

For us simple windows folks, there are encoding issues when opening the mock json data with `file.open()`. There doesn't appear to be any issues with converting the mock data function to `read_json(file)`

### Checklist

- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if applicable)
- [ ] All lint and unit tests passing
- [ ] Extended the README / documentation, if necessary

### Additional Comments

The `managers` is the only test that fails. 

```
FAILED tests/test_client.py::TestClient::test_get_managers - UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 5419: character maps to <undefined>
```

Another option might be to add an encoding parameter to `file.open()`. I believe mine is running with `encoding='cp1252'`
