### PR TITLE
Resolve future deprecation warning by wrapping json string with StringIO

### DIFF
--- a/itscalledsoccer/client.py
+++ b/itscalledsoccer/client.py
@@ -7,6 +7,7 @@ import requests
 from cachecontrol import CacheControl
 from cachecontrol.heuristics import ExpiresAfter
 from rapidfuzz import fuzz, process
+from io import StringIO
 
 
 class AmericanSoccerAnalysis:
@@ -300,7 +301,7 @@ class AmericanSoccerAnalysis:
         """
         response = self.session.get(url=url, params=params)
         response.raise_for_status()
-        resp_df = read_json(json.dumps(response.json()))
+        resp_df = read_json(StringIO(json.dumps(response.json())))
         return resp_df
 
     def _get_stats(


### PR DESCRIPTION
### Description

The current approach of creating a Pandas DataFrame from an API response emits a future depreciation warning. For example, if we run `pytest` we get the below warnings:

```
tests/test_client.py: 11 warnings
  C:\Users\my_path\itscalledsoccer\client.py:303: FutureWarning: Passing literal json to 'read_json' is deprecated and will be removed in a future version. To read from a literal string, wrap it in a 'StringIO' object.
    resp_df = read_json(json.dumps(response.json()))
```

This is resolved by wrapping the json string with `StringIO`:
```python
resp_df = read_json(StringIO(json.dumps(response.json())))
```




### Checklist

- [X] Code compiles correctly
- [X] Created tests which fail without the change (if applicable)
- [X] All lint and unit tests passing
- [X] Extended the README / documentation, if necessary

### Additional Comments

Anything else you'd like to add.
