### PR TITLE
Resolve ruff related warnings and add ruff format command to documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,11 +187,18 @@ With the dependencies installed, you're now ready to make your changes. All of t
 
 ##### Linting and formatting
 
-`itscalledsoccer`uses [mypy](https://www.mypy-lang.org/) for static type checking and [ruff](https://docs.astral.sh/ruff/) for formatting. Running both looks similar:
+`itscalledsoccer` uses [mypy](https://www.mypy-lang.org/) for static type checking.
 
 ```sh
 mypy itscalledsoccer
-ruff itscalledsoccer
+```
+
+
+`itscalledsoccer` [ruff](https://docs.astral.sh/ruff/) for formatting. 
+
+```sh
+ruff check itscalledsoccer
+ruff format itscalledsoccer
 ```
 
 ##### Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,7 +194,7 @@ mypy itscalledsoccer
 ```
 
 
-`itscalledsoccer` [ruff](https://docs.astral.sh/ruff/) for formatting. 
+`itscalledsoccer` uses [ruff](https://docs.astral.sh/ruff/) for formatting. 
 
 ```sh
 ruff check itscalledsoccer

--- a/itscalledsoccer/client.py
+++ b/itscalledsoccer/client.py
@@ -20,7 +20,10 @@ class AmericanSoccerAnalysis:
     LOGGER = getLogger(__name__)
 
     def __init__(
-        self, proxies: Optional[dict] = None, logging_level: Optional[str] = "WARNING", lazy_load: Optional[bool] = True
+        self,
+        proxies: Optional[dict] = None,
+        logging_level: Optional[str] = "WARNING",
+        lazy_load: Optional[bool] = True,
     ) -> None:
         """Class constructor
 
@@ -57,9 +60,13 @@ class AmericanSoccerAnalysis:
         self.referees: DataFrame = None
 
         if self.lazy_load:
-            self.LOGGER.info("Lazy loading enabled. Initializing client without entity data.")
+            self.LOGGER.info(
+                "Lazy loading enabled. Initializing client without entity data."
+            )
         else:
-            self.LOGGER.info("Lazy loading disabled. Initializing client with entity data.")
+            self.LOGGER.info(
+                "Lazy loading disabled. Initializing client with entity data."
+            )
             self.players = self._get_entity("player")
             self.teams = self._get_entity("team")
             self.stadia = self._get_entity("stadia")
@@ -491,7 +498,7 @@ class AmericanSoccerAnalysis:
             DataFrame_
         """
         if self.players is None:
-            self.players = self._get_entity("player") 
+            self.players = self._get_entity("player")
         players = self._filter_entity(self.players, "player", leagues, ids, names)
         return players
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,5 +64,5 @@ module = [
 ]
 ignore_missing_imports = true
 
-[tool.ruff]
+[tool.ruff.lint]
 ignore = ["E501"]


### PR DESCRIPTION
Resolve ruff related warnings and add ruff format command to documentation

### Description

**Impact 1**: resolve ruff warnings

Contributing.md currently recommends to run `ruff itscalledsoccer` but this returns 2 ruff related warnings:
```
warning: `ruff <path>` is deprecated. Use `ruff check <path>` instead.
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
```
These warnings are resolved by running `ruff check itscalledsoccer` and making a small change to the ruff section in pyproject.toml

**Impact 2**: add formatting command

I also added `ruff format` command to contribution.md. This actually reformats the codebase and you can see that `client.py` has a few formatting related changes. Let me know if we want to add this as a contribution step. If not, I can remove it and this PR can focus on just resolving the ruff warnings.


### Checklist

- [X] Code compiles correctly
- [X] Created tests which fail without the change (if applicable)
- [X] All lint and unit tests passing
- [X] Extended the README / documentation, if necessary

### Additional Comments

Anything else you'd like to add.
