### PR TITLE
Add test coverage

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -34,3 +34,7 @@ jobs:
         with:
           pytest-coverage-path: ./pytest-coverage.txt
           junitxml-path: ./pytest.xml
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -26,6 +26,11 @@ jobs:
         run: |
           mypy itscalledsoccer
           ruff check itscalledsoccer
-      - name: Pytest
+      - name: Run Pytest and generate coverage file
         run: |
-          pytest
+          pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=itscalledsoccer tests/ | tee pytest-coverage.txt
+      - name: Pytest coverage comment
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          pytest-coverage-path: ./pytest-coverage.txt
+          junitxml-path: ./pytest.xml

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -29,11 +29,6 @@ jobs:
       - name: Run Pytest and generate coverage file
         run: |
           pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=itscalledsoccer tests/ | tee pytest-coverage.txt
-      - name: Pytest coverage comment
-        uses: MishaKav/pytest-coverage-comment@main
-        with:
-          pytest-coverage-path: ./pytest-coverage.txt
-          junitxml-path: ./pytest.xml
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,7 @@ For more information, see the [venv documentation](https://docs.python.org/3/lib
 The following command will install the appropriate dependencies in the virtual environment you just created.
 
 ```sh
-pip install ".[dev]"
+pip install ".[test]"
 ```
 
 #### Make your changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,6 +209,14 @@ ruff format itscalledsoccer
 pytest
 ```
 
+Whenever you add or modify code, you should ensure that your changes have test coverage. To create a test coverage report, run the below command. 
+
+```sh
+pytest --cov=itscalledsoccer --cov-report=html
+```
+Open htmlcov/index.html in a browser and review the generated coverage report.
+
+
 #### Open a pull request
 
 Once the tests are in good shape and the code has been linted and formatted, you're ready to open a pull request (PR). The [GitHub docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) provide great instructions on how to do just that.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ version = "1.2.1"
 Repository = "https://github.com/American-Soccer-Analysis/itscalledsoccer"
 
 [project.optional-dependencies]
-dev = [
+test = [
   "types-requests",
   "pytest",
   "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,10 @@ version = "1.2.1"
 Repository = "https://github.com/American-Soccer-Analysis/itscalledsoccer"
 
 [project.optional-dependencies]
-test = [
+dev = [
   "types-requests",
   "pytest",
+  "pytest-cov",
   "mypy",
   "ruff",
   "mkdocs",


### PR DESCRIPTION
### Description

Add test coverage (https://github.com/American-Soccer-Analysis/itscalledsoccer/issues/181)

The `.github/workflows/python-tests.yml` workflow now:
- Creates test coverage report with [pytest-cov](https://pypi.org/project/pytest-cov/)
- Creates a comment in PR with test coverage info
- Uploads coverage info to Codecov
- See this PR on my fork as an example of what happens: https://github.com/rbarman/itscalledsoccer/pull/6#issuecomment-2226760053

Also updated `CONTRIBUTING.md` with steps on how to locally generate the test coverage report.


### Checklist

- [X] Code compiles correctly
- [X] Created tests which fail without the change (if applicable)
- [X] All lint and unit tests passing
- [X] Extended the README / documentation, if necessary

### Additional Comments

Repo owners will need to enable this repo with Codecov and set the `CODECOV_TOKEN` as a repository secret.

