### PR TITLE
Use uv to deploy GH Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up uv
         # Install a specific uv version using the installer
         run: |
-          curl -LsSf https://astral.sh/uv/0.3.3/install.sh | sh
+          curl -LsSf https://astral.sh/uv/0.3.4/install.sh | sh
           uv venv
           uv pip install --upgrade setuptools wheel
       - name: Install the project

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -19,4 +19,4 @@ jobs:
           uv pip install --upgrade setuptools wheel
       - name: Install the project
         run: uv sync --all-extras --dev
-      - run: mkdocs gh-deploy --force
+      - run: uv run mkdocs gh-deploy --force

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -20,9 +20,7 @@ jobs:
       - name: Set up uv
         # Install a specific uv version using the installer
         run: |
-          curl -LsSf https://astral.sh/uv/0.3.3/install.sh | sh
-          uv venv
-          uv pip install --upgrade setuptools wheel 
+          curl -LsSf https://astral.sh/uv/0.3.4/install.sh | sh
       - name: Install the project
         run: uv sync --all-extras --dev
       - name: Linting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "itscalledsoccer"
 description = "Programmatically interact with the American Soccer Analysis API"
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
   { name = "American Soccer Analysis", email = "americansocceranalysis@gmail.com" },
 ]
@@ -28,7 +28,7 @@ dependencies = [
   "requests>=2.31.0",
   "CacheControl>=0.13.1",
   "rapidfuzz>=3.2.0",
-  "pandas>=2.0.3",
+  "pandas>=2.1.0",
 ]
 version = "1.2.2"
 


### PR DESCRIPTION
### Description

Need to use `uv` to deploy GH pages since `mkdocs` is installed by it

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if applicable)
- [x] All lint and unit tests passing
- [x] Extended the README / documentation, if necessary
