### PR TITLE
Enable attestation support for PyPI publishing and add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -25,3 +25,5 @@ jobs:
           python -m build
       - name: Publish a Python distribution to PyPi
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,36 @@
+name: Scorecard supply-chain security
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '32 23 * * 6'
+  push:
+    branches: [ "main" ]
+permissions: read-all
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
### Description

[Attestation support](https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#generating-and-uploading-attestations) and [Scorecard info](https://scorecard.dev/#what-is-openssf-scorecard)

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if applicable)
- [x] All lint and unit tests passing
- [x] Extended the README / documentation, if necessary
