### PR TITLE
fix: gh pages action

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: ~
 permissions:
   contents: read
 
@@ -20,7 +21,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
-          python-version: 3.x
+          python-version: 3.12
       - name: Set up uv
         # Install a specific uv version using the installer
         run: |


### PR DESCRIPTION
### Description

Fixing the GitHub pages action. `pandas` is pulling in an older version of `cython`: https://github.com/cython/cython/issues/5790#issuecomment-2215781375

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if applicable)
- [x] All lint and unit tests passing
- [x] Extended the README / documentation, if necessary

