### PR TITLE
fix: lazy-load entities before name lookup

### DIFF
--- a/itscalledsoccer/client.py
+++ b/itscalledsoccer/client.py
@@ -118,6 +118,9 @@ class AmericanSoccerAnalysis:
 
         attr, name_col, id_col = TYPE_MAP[entity_type]
         lookup = getattr(self, attr)
+        if lookup is None:
+            lookup = self._get_entity(entity_type)
+            setattr(self, attr, lookup)
         names = lookup[name_col].to_list()
 
         matches = process.extractOne(name, names, scorer=fuzz.partial_ratio)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -240,6 +240,22 @@ class TestClient:
 
         assert player_id == "p1"
 
+    def test_convert_name_to_id_lazy_loads_missing_entity(self):
+        self.client = AmericanSoccerAnalysis()
+        teams = DataFrame(
+            [
+                {"team_id": "t1", "team_name": "LAFC", "competition": "mls"},
+                {"team_id": "t2", "team_name": "NYCFC", "competition": "mls"},
+            ]
+        )
+
+        with patch.object(self.client, "_get_entity", return_value=teams) as mock_get_entity:
+            team_id = self.client._convert_name_to_id("team", "LAFC")
+
+        assert team_id == "t1"
+        assert self.client.teams is teams
+        mock_get_entity.assert_called_once_with("team")
+
     def test_convert_names_to_ids_with_list(self):
         self.client = AmericanSoccerAnalysis()
         self.client.teams = DataFrame(


### PR DESCRIPTION
Fixes #286.

This keeps lazy loading enabled, but when `_convert_name_to_id()` needs an entity table that has not been loaded yet it now loads that specific entity and caches it on the client before fuzzy matching.

Added a focused regression test covering the lazy-load path for team-name lookup.

Verification:
- `python3 -m py_compile itscalledsoccer/client.py tests/test_client.py`
- `git diff --check`

I could not run the pytest suite in this runtime because `pytest` is not installed here.